### PR TITLE
Basic syntax updates

### DIFF
--- a/create_product.php
+++ b/create_product.php
@@ -11,7 +11,7 @@
 
 	try
 	{
-		# Making an API request can throw an exception
+		// Making an API request can throw an exception
 		$product = $shopify('POST /admin/products.json', array(), array
 		(
 			'product' => array
@@ -41,17 +41,17 @@
 	}
 	catch (shopify\ApiException $e)
 	{
-		# HTTP status code was >= 400 or response contained the key 'errors'
+		// HTTP status code was >= 400 or response contained the key 'errors'
 		echo $e;
-		print_R($e->getRequest());
-		print_R($e->getResponse());
+		print_r($e->getRequest());
+		print_r($e->getResponse());
 	}
 	catch (shopify\CurlException $e)
 	{
-		# cURL error
+		// cURL error
 		echo $e;
-		print_R($e->getRequest());
-		print_R($e->getResponse());
+		print_r($e->getRequest());
+		print_r($e->getResponse());
 	}
 
 ?>

--- a/get_products.php
+++ b/get_products.php
@@ -11,23 +11,23 @@
 
 	try
 	{
-		# Making an API request can throw an exception
+		// Making an API request can throw an exception
 		$products = $shopify('GET /admin/products.json', array('published_status'=>'published'));
 		print_r($products);
 	}
 	catch (shopify\ApiException $e)
 	{
-		# HTTP status code was >= 400 or response contained the key 'errors'
+		// HTTP status code was >= 400 or response contained the key 'errors'
 		echo $e;
-		print_R($e->getRequest());
-		print_R($e->getResponse());
+		print_r($e->getRequest());
+		print_r($e->getResponse());
 	}
 	catch (shopify\CurlException $e)
 	{
-		# cURL error
+		// cURL error
 		echo $e;
-		print_R($e->getRequest());
-		print_R($e->getResponse());
+		print_r($e->getRequest());
+		print_r($e->getResponse());
 	}
 
 ?>

--- a/get_shop.php
+++ b/get_shop.php
@@ -11,23 +11,23 @@
 
 	try
 	{
-		# Making an API request can throw an exception
+		// Making an API request can throw an exception
 		$shop = $shopify('GET /admin/shop.json');
 		print_r($shop);
 	}
 	catch (shopify\ApiException $e)
 	{
-		# HTTP status code was >= 400 or response contained the key 'errors'
+		// HTTP status code was >= 400 or response contained the key 'errors'
 		echo $e;
-		print_R($e->getRequest());
-		print_R($e->getResponse());
+		print_r($e->getRequest());
+		print_r($e->getResponse());
 	}
 	catch (shopify\CurlException $e)
 	{
-		# cURL error
+		// cURL error
 		echo $e;
-		print_R($e->getRequest());
-		print_R($e->getResponse());
+		print_r($e->getRequest());
+		print_r($e->getResponse());
 	}
 
 ?>


### PR DESCRIPTION
Replaced some syntax to prevent warnings/errors in PHP regarding "#" being depreciated as comments, and corrected print_R to be print_r, as the function doesn't use uppercase letters.
